### PR TITLE
Fix `resetConn` to reset `dbConnection` to null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const setupConfig = (options) => {
 };
 
 const resetConn = () => {
-  dbConnection = {};
+  dbConnection = null;
 };
 
 const resetBatch = () => {


### PR DESCRIPTION
Fix bug causing an error on next `insertToMongo` after `resetConn`.

Changed reset value to null (as initial value) because
in writeable.write `dbConnection` will be checked for a falsy value

https://github.com/AbdullahAli/node-stream-to-mongo-db/blob/9c63e517bc79bfd1f28a1c517fa3515ead0487bf/src/index.js#L48

and empty object after `resetConn` will be treated as existing connection
causing an error

> dbConnection.collection is not a function

at https://github.com/AbdullahAli/node-stream-to-mongo-db/blob/9c63e517bc79bfd1f28a1c517fa3515ead0487bf/src/index.js#L21
