### PR TITLE
:sparkles: remove the need of global variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-to-mongo-db",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Stream data directly to MongoDB",
   "main": "out/index.js",
   "scripts": {

--- a/src/spec/index_spec.js
+++ b/src/spec/index_spec.js
@@ -62,15 +62,15 @@ const runStreamTest = (options, done) => {
       done();
     })
     .on('close', () => {
-      ensureAllDocumentsInserted(done)
-    })
+      ensureAllDocumentsInserted(done);
+    });
 };
 
 const ensureAllDocumentsInserted = async (done) => {
   const db = await connect();
   const count = await db.collection(config.collection).count();
   await db.close();
-  expect(expectedNumberOfRecords).toEqual(count);
+  expect(count).toEqual(expectedNumberOfRecords);
   done();
 };
 


### PR DESCRIPTION
My client had some issue streaming in parallels.

So I limited the variables scope :)