### PR TITLE
Support for caller provided Mongodb connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ fs.createReadStream('./myJsonData.json')
 
     eg: `mongodb://localhost:27017/streamToMongoDB`
 
+- `dbConnection`
+
+    **[ OPTIONAL - Object ]**
+
+    An optional connection to mongodb (By default, stream-to-mongo-db will open a new mongo connection). When provided, dbUrl will be ignored.
+
 - `collection`    
 
     **[ REQUIRED - String ]**


### PR DESCRIPTION
This modification allows for sharing a connection with the caller, and for easier mocking (With this changes it is possible to use a mongo-mock connection).