### PR TITLE
Ensure records flushed before `final` event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,8 @@ module.exports = {
     // stream
     const writable = new Writable({
       objectMode: true,
+      autoDestroy: false, // Force nodejs-8.xx like functionality
+      emitClose: false, // Force nodejs-8.xx like functionality
       write: async (record, encoding, next) => {
         // connection
         if (!dbConnection) {

--- a/src/spec/index_spec.js
+++ b/src/spec/index_spec.js
@@ -7,7 +7,7 @@ import StreamToMongoDB from '../index';
 
 const DATA_FILE_LOCATION = path.resolve('src/spec/support/data.json');
 const testDB = 'streamToMongoDB';
-var config;
+let config;
 
 const expectedNumberOfRecords = require('./support/data.json').length;
 


### PR DESCRIPTION
This should make #11 a bit easier to implement as the events more closely align with the stream spec.

Notably:

> The 'finish' event is emitted after the stream.end() method has been called, **and all data has been flushed to the underlying system**.
> * https://nodejs.org/docs/latest/api/stream.html#stream_writable_final_callback 
> * https://nodejs.org/docs/latest/api/stream.html#stream_event_finish

It also forces the functionality of nodejs-8 event handling onto the stream to ensure consistent event handling across all versions supported.